### PR TITLE
minor: Fixed deprecation warning in platform check

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,7 @@ default["takipi"]["home"] = "/opt/takipi"
 default["takipi"]["base"] = "/opt/"
 default["takipi"]["server_name"] = "YOUR SERVER NAME HERE"
 
-default["takipi"]["java_arch"] = if platform? "ubuntu" and platform_version >= "11.10"
+default["takipi"]["java_arch"] = if (platform == "ubuntu") and (platform_version >= "11.10")
                                    if kernel.machine == "x86_64"
                                      "amd64"
                                    else


### PR DESCRIPTION
Under chef 10.24, using "platform?" caused a warning of "Setting attributes without specifying a precedence". This seems related to the bug http://tickets.opscode.com/browse/COOK-1929
