### PR TITLE
Added support for Amazon Linux

### DIFF
--- a/files/amazon/takipi.init
+++ b/files/amazon/takipi.init
@@ -1,0 +1,1 @@
+../ubuntu/takipi.init

--- a/files/default/takipi.init
+++ b/files/default/takipi.init
@@ -1,0 +1,1 @@
+../ubuntu/takipi.init


### PR DESCRIPTION
Tested on AWS OpsWorks.

Also added a `default` fallback for distributions that are neither Amazon Linux, CentOS, Debian, nor Ubuntu.
That fallback will try to install the Ubuntu init file.
