### PR TITLE
Allow choosing the package action via an attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG for takipi
 
+Allow chosing the package action (install/upgrade/remove) via `node["takipi"]["package_action”]` wrapper cookbook attribute.
+
 0.5.3
 Added an option to change machine_name in Takipi
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Make sure you include your Takipi secret key as custom Chef JSON:
 ```
 {
   "takipi": {
-    "secret_key": "YOUR SECRET KEY"
+    "secret_key": "YOUR SECRET KEY",
     "machine_name": ""
   }
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default["takipi"]["secret_key"] = "YOUR SECRET KEY HERE"
 default["takipi"]["machine_name"] = ""
+default["takipi"]["package_action"] = "install"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,7 @@ bash "setup_machine_name" do
   ./takipi-setup-machine-name #{node["takipi"]["machine_name"]}
   EOH
   action :run
-  not_if do node["takipi"]["machine_name"] == "" end
+  not_if {node["takipi"]["machine_name"] == ""}
 end
 
 bash "setup_secret_key" do
@@ -49,11 +49,11 @@ bash "setup_secret_key" do
     ./takipi-setup-package #{node["takipi"]["secret_key"]}
     EOH
   action :run
-  not_if do ::File.exists?(::File.join("opt", "takipi", "work", "secret.key")) end
+  not_if {::File.exists?(::File.join("opt", "takipi", "work", "secret.key"))}
 end
 
 log "fail_message" do
   message "Takipi failed to install. Did you forget to add a Takipi secret_key?"
   level :error
-  not_if do ::File.exists?(::File.join("opt", "takipi", "work", "secret.key")) end
+  not_if {::File.exists?(::File.join("opt", "takipi", "work", "secret.key"))}
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@ case node.platform_family
     end
 
     apt_package "takipi" do
-      action :install
+      action node["takipi"]["package_action"]
     end
   when "rhel", "suse"
     yum_repository 'takipi' do
@@ -30,7 +30,7 @@ case node.platform_family
     end
 
     yum_package "takipi" do
-      action :install
+      action node["takipi"]["package_action"]
     end
 end
 


### PR DESCRIPTION
Users of the cookbook can now choose between installing the package once, upgrading to each new version, or removing the package using the ﻿node["takipi"]["package_action"] attribute.

Also, some syntax fixes =)