### PR TITLE
Add service restart on upgrades, unify the package resource.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,10 +16,6 @@ case node.platform_family
       arch "amd64"
       key "https://s3.amazonaws.com/takipi-deb-repo/hello@takipi.com.gpg.key"
     end
-
-    apt_package "takipi" do
-      action node["takipi"]["package_action"]
-    end
   when "rhel", "suse"
     yum_repository 'takipi' do
       description "Takipi repo"
@@ -28,10 +24,10 @@ case node.platform_family
       gpgcheck false
       action :create
     end
+end
 
-    yum_package "takipi" do
-      action node["takipi"]["package_action"]
-    end
+package "takipi" do
+  action node["takipi"]["package_action"]
 end
 
 bash "setup_machine_name" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,7 @@ end
 
 package "takipi" do
   action node["takipi"]["package_action"]
+  notifies :restart, "service[takipi]", :delayed
 end
 
 bash "setup_machine_name" do
@@ -36,6 +37,8 @@ bash "setup_machine_name" do
   ./takipi-setup-machine-name #{node["takipi"]["machine_name"]}
   EOH
   action :run
+  notifies :restart, "service[takipi]", :delayed
+  not_if "test -s /opt/takipi/takipi.properties"
   not_if {node["takipi"]["machine_name"] == ""}
 end
 
@@ -45,7 +48,13 @@ bash "setup_secret_key" do
     ./takipi-setup-package #{node["takipi"]["secret_key"]}
     EOH
   action :run
+  notifies :restart, "service[takipi]", :delayed
   not_if {::File.exists?(::File.join("opt", "takipi", "work", "secret.key"))}
+end
+
+service "takipi" do
+  action [:enable, :start]
+  supports :restart => true, :stop => true, :start => true, :status => true
 end
 
 log "fail_message" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,6 @@ bash "setup_machine_name" do
   ./takipi-setup-machine-name #{node["takipi"]["machine_name"]}
   EOH
   action :run
-  notifies :restart, "service[takipi]", :delayed
   not_if "test -s /opt/takipi/takipi.properties"
   not_if {node["takipi"]["machine_name"] == ""}
 end
@@ -48,7 +47,6 @@ bash "setup_secret_key" do
     ./takipi-setup-package #{node["takipi"]["secret_key"]}
     EOH
   action :run
-  notifies :restart, "service[takipi]", :delayed
   not_if {::File.exists?(::File.join("opt", "takipi", "work", "secret.key"))}
 end
 


### PR DESCRIPTION
Also, only run takipi-setup-machine-name if takipi.properties is empty.